### PR TITLE
sdm660-common: Switch to cosmic clang conditionally

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -80,8 +80,13 @@ BOARD_KERNEL_PAGESIZE    := 4096
 BOARD_KERNEL_IMAGE_NAME  := Image.gz-dtb
 
 TARGET_KERNEL_SOURCE := kernel/asus/sdm660
-TARGET_KERNEL_VERSION := 4.19
-#TARGET_KERNEL_CLANG_VERSION := proton
+
+ifeq ($(CUSTOM_CLANG),true)
+TARGET_KERNEL_CLANG_VERSION := cosmic
+TARGET_KERNEL_CLANG_PATH := $(shell pwd)/prebuilts/clang/host/linux-x86/clang-cosmic
+TARGET_KERNEL_ADDITIONAL_FLAGS := AR=llvm-ar AS=llvm-as NM=llvm-nm LD=ld.lld OBJCOPY=llvm-objcopy OBJDUMP=llvm-objdump OBJSIZE=llvm-size READELF=llvm-readelf STRIP=llvm-strip HOSTAR=llvm-ar HOSTAS=llvm-as HOSTNM=llvm-nm HOSTLD=ld.lld
+endif
+
 TARGET_KERNEL_ADDITIONAL_FLAGS := \
     HOSTCFLAGS="-fuse-ld=lld -Wno-unused-command-line-argument"
 

--- a/lineage.dependencies
+++ b/lineage.dependencies
@@ -1,0 +1,18 @@
+[
+  {
+    "repository":  "android_kernel_asus_sdm660",
+    "target_path": "kernel/asus/sdm660"
+  },
+  {
+    "remote": "github",
+    "repository": "ArrowOS-Devices/android_packages_apps_GCamGOPrebuilt",
+    "target_path": "packages/apps/GCamGOPrebuilt",
+    "branch": "arrow-13.0"
+  },
+  {
+    "remote": "gitlab",
+    "repository": "GhostMaster69-dev/cosmic-clang",
+    "target_path": "prebuilts/clang/host/linux-x86/clang-cosmic",
+    "branch": "master"
+  }
+]


### PR DESCRIPTION
 - as arrow jenkins builds are not compilable with custom clang due to outdated glibc version

Signed-off-by: Sonal Singh <sonal.singh.19993@gmail.com>